### PR TITLE
Updates to flow linting

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -1,14 +1,21 @@
 module.exports = {
     "plugins": [
-        "flowtype",
-        "flow-vars"
+        "flowtype"
     ],
     "rules": {
-        "flow-vars/define-flow-type": 1,
-        "flow-vars/use-flow-type": 1,
-        "flowtype/require-parameter-type": [2, {"excludeArrowFunctions": true }],
-        "flowtype/require-return-type": [2, "always", {"excludeArrowFunctions": true}],
-        "flowtype/space-after-type-colon": [1, "always"],
-        "flowtype/space-before-type-colon": [1, "never"]
+        "flowtype/delimiter-dangle": [2, "never"], // Don't allow trailing commas
+        "flowtype/define-flow-type": 1, // Marks Flow type identifiers as defined
+        "flowtype/use-flow-type": 1, //Marks Flow type alias declarations as used.
+        "flowtype/generic-spacing": [2, "never"], // Don't allow spaces in generic type annotations, eg. `Promise< any >`
+        "flowtype/no-dupe-keys": [2, "never"], // Don't allow duplicates in object annotations
+        "flowtype/no-primitive-constructor-types": [2, "never"], // Don't allow use of String, Boolean, etc
+        "flowtype/object-type-delimiter": [2, "comma"], // Enforce commas for object annotation delimiters
+        "flowtype/require-parameter-type": [2, {"excludeArrowFunctions": "expressionsOnly" }], // Require param type for everything except expression only arrow functions
+        "flowtype/require-return-type": [2, "always", {"excludeArrowFunctions": "expressionsOnly"}],
+        "flowtype/require-valid-file-annotation": [2, "always"], // enforce having @flow at top of file
+        "flowtype/semi": [2, "always"], // require semicolon after type aliases
+        "flowtype/space-after-type-colon": [2, "always"], // Require space after type annotation colon
+        "flowtype/space-before-generic-bracket": [2, "never"], // Don't allow spaces between type and generic bracket
+        "flowtype/space-before-type-colon": [2, "never"]
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 module.exports = {
     extends: [
         "eslint:recommended",
-        "plugin:react/recommended",
         "eslint-config-blueflag/src/parser",
-        "eslint-config-blueflag/src/react",
         "eslint-config-blueflag/src/javascript"
-    ]    
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
   "author": "Allan hortle",
   "license": "ISC",
   "dependencies": {
-    "babel-eslint": "^6.0.3",
-    "eslint": "2.4.0",
-    "eslint-plugin-flow-vars": "^0.3.0",
-    "eslint-plugin-flowtype": "^2.2.6",
-    "eslint-plugin-react": "^5.0.1"
+    "babel-eslint": "^7.1.1",
+    "eslint": "3.12.2",
+    "eslint-plugin-flowtype": "^2.29.1",
+    "eslint-plugin-react": "^6.8.0"
   }
 }

--- a/react.js
+++ b/react.js
@@ -2,6 +2,9 @@ module.exports = {
     plugins: [
         "react"
     ],
+    "extends": [
+        "plugin:react/recommended",
+    ],
     rules: {
         // React
         'react/no-danger': 0,

--- a/src/javascript.js
+++ b/src/javascript.js
@@ -6,7 +6,9 @@ module.exports = {
         'space-in-parens': 2,
         'no-console': 0,
         indent: [2, 4, {
-            SwitchCase: 1 
-        }]
+            SwitchCase: 1
+        }],
+        "semi": [2, "always"],
+        "comma-dangle": [2, "never"]
     }
 }


### PR DESCRIPTION
Added a bunch of new rules for flow and just generally updated dependencies and stuff. Also moved react linting out to be included separately.

Previously you would just have:

```
{
    "extends": [
        "eslint-config-blueflag",
        "eslint-config-blueflag/flow"
    ]
}
```

But now you do:

```
{
    "extends": [
        "eslint-config-blueflag",
        "eslint-config-blueflag/react",
        "eslint-config-blueflag/flow"
    ]
}
```

Mainly just for consistency with including flow.